### PR TITLE
Update Slicer3 download links

### DIFF
--- a/slicer4DownloadServer/templates/download.html
+++ b/slicer4DownloadServer/templates/download.html
@@ -97,7 +97,7 @@
             <li><a href="http://wiki.slicer.org/slicerWiki/index.php/Help">General help</a></li>
             <li><a href="http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Report_a_problem">Reporting problems</a></li>
             <li><a href="http://wiki.slicer.org/slicerWiki/index.php/Documentation/Release/Acknowledgments">Acknowledgements</a></li>
-            <li><a href="http://www.slicer.org/pages/Special:SlicerDownloads">Slicer3 download</a></li>
+            <li><a href="https://www.slicer.org/download_files/Release/">Slicer3 download</a></li>
             <li><a href="http://wiki.slicer.org/slicerWiki/index.php/License">License</a></li>
             <li><a href="http://wiki.slicer.org/slicerWiki/index.php/Contact">Contact us</a></li>
 


### PR DESCRIPTION
As documented in Slicer issue 4237 [1], the regular download page is broken. This commit changes the link to an "Index" page listing folders for each Slicer3 operating system where each folders contains installers and/or archives.

[1] http://na-mic.org/Mantis/view.php?id=4237
