### PR TITLE
download: Remove plus sign associated with Nightly

### DIFF
--- a/slicer4DownloadServer/templates/download.html
+++ b/slicer4DownloadServer/templates/download.html
@@ -66,15 +66,15 @@
             <tr>
                 <th>Nightly Build</th>
                 <td><a href="{{R.win.nightly.download_url}}" class="button expanded hollow warning">
-                        <span class="header">version {{R.win.nightly.version}}+</span>
+                        <span class="header">version {{R.win.nightly.version}}</span>
                         <br/>revision {{R.win.nightly.revision}}
                         <br/>built {{R.win.nightly.build_date_ymd}}</a></td>
                 <td><a href="{{R.macosx.nightly.download_url}}" class="button expanded hollow warning">
-                        <span class="header">version {{R.macosx.nightly.version}}+</span>
+                        <span class="header">version {{R.macosx.nightly.version}}</span>
                         <br/>revision {{R.macosx.nightly.revision}}
                         <br/>built {{R.macosx.nightly.build_date_ymd}}</a></td>
                 <td><a href="{{R.linux.nightly.download_url}}" class="button expanded hollow warning">
-                        <span class="header">version {{R.linux.nightly.version}}+</span>
+                        <span class="header">version {{R.linux.nightly.version}}</span>
                         <br/>revision {{R.linux.nightly.revision}}
                         <br/>built {{R.linux.nightly.build_date_ymd}}</a></td>
             </tr>


### PR DESCRIPTION
Since we updated our version scheme to have the nightly be `X.(Y+1).Z` with `X.Y.Z` being the last release, the plus sign is not needed anymore.

See http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=25442
