### PR TITLE
download-page: Add "Getting Started" link

### DIFF
--- a/slicer4-downloadserver/templates/download.html
+++ b/slicer4-downloadserver/templates/download.html
@@ -108,6 +108,7 @@
     <div class="medium-4 columns">
         <h3>For users</h3>
         <ul>
+            <li><a href="https://www.slicer.org/wiki/New_users">Getting Started</a></li>
             <li><a href="https://www.slicer.org/wiki/Documentation/UserTraining">Training and tutorials</a></li>
             <li><a href="https://www.slicer.org/wiki/Documentation/Release">User documentation</a></li>
             <li><a href="http://www.slicer.org/pages/Slicer_Community">Slicer in use</a></li>


### PR DESCRIPTION
See https://discourse.slicer.org/t/new-users-link-for-the-download-page/6793

Co-authored-by: Andrey Fedorov <fedorov@bwh.harvard.edu>

Here is a preview of the change:

![image](https://user-images.githubusercontent.com/219043/57746269-76b51500-769e-11e9-9a1d-110ffbdf1d4e.png)
