### PR TITLE
download: Fix macOS minimum required version from 10.9 to 10.13

### DIFF
--- a/slicer4-downloadserver/templates/download.html
+++ b/slicer4-downloadserver/templates/download.html
@@ -28,7 +28,8 @@
     <div class="medium-12 columns">
         <div class="callout intro">
             <p>You are one click away from downloading 3D Slicer, a free and open-source platform for analyzing and understanding medical image data. Created through multiple grants from the US National Institutes of Health (NIH) over almost two decades, Slicer brings powerful medical image processing, visualization, and data analysis tools within reach of everyone.</p>
-            <p>Slicer is built and tested on many hardware and software platforms. 3D Slicer runs on modern Windows, macOS (10.9 and up), and a variety of Linux distributions.</p>
+            <p>Slicer is built and tested on many hardware and software platforms. 3D Slicer runs on modern Windows, macOS, and a variety of Linux distributions.
+            <br/>Read about <a href="https://slicer.readthedocs.io/en/latest/user_guide/getting_started.html#system-requirements">system requirements</a>.</p>
     </p>
 </div>
             <h2>Installers</h2>


### PR DESCRIPTION
Based on changes from https://github.com/Slicer/Slicer/pull/4940.

@jcfr This updates the text to say macOS 10.13 and up which is technically only for Slicer Preview as of right now while Slicer 4.10.2 I think supports down to 10.9.  Is this fine or should there be two specifications explained on the webpage?