### PR TITLE
ENH: Replace non-HTTPS download links with HTTPS links

### DIFF
--- a/slicer4-downloadserver/__init__.py
+++ b/slicer4-downloadserver/__init__.py
@@ -13,7 +13,7 @@ StabilityChoices = ('release', 'nightly', 'any')
 ModeChoices = ('revision', 'closest-revision',
                'version', 'checkout-date', 'date')
 
-DownloadURLBase = 'http://slicer.kitware.com/midas3/download'
+DownloadURLBase = 'https://slicer.kitware.com/midas3/download'
 LocalBitstreamPath = '/bitstream'
 
 app = flask.Flask(__name__)
@@ -102,7 +102,7 @@ def cleanupMidasRecord(r):
 
 def getLocalBitstreamURL(r):
     """Given a record, return the URL of the local bitstream
-    (e.g., http://download.slicer.org/bitstream/XXXXX )"""
+    (e.g., https://download.slicer.org/bitstream/XXXXX )"""
     bitstreamId = r['bitstreams'][0]['bitstream_id']
 
     downloadURL = '{0}/{1}'.format(LocalBitstreamPath, bitstreamId)


### PR DESCRIPTION
Google Chrome is planning to block non-HTTPS download links started on secure pages.

See https://www.chromestatus.com/feature/5691978677223424

Originally mentioned in https://discourse.slicer.org/t/slicer-downloads-are-warned-as-unsecure-by-google-chrome/12836

CC: @mhalle 