### PR TITLE
Revert "Mark Preview release as unstable"

### DIFF
--- a/slicer4-downloadserver/templates/download.html
+++ b/slicer4-downloadserver/templates/download.html
@@ -65,7 +65,7 @@
                 </td>
             </tr>
             <tr>
-              <th>Preview Release<br/><span style="color:red;font-weight:bold">Unstable!</span></th>
+                <th>Preview Release</th>
                 <td><a href="{{R.win.nightly.download_url}}" class="button expanded hollow warning">
                         <span class="header">version {{R.win.nightly.version}}</span>
                         <br/>revision {{R.win.nightly.revision}}


### PR DESCRIPTION
Following the resolution of all critical VTK 9 related
issues, this reverts commit 41a142464816f7fabdda7924a46b0257f5643925.